### PR TITLE
refactor: 칼럼 관리(수정) 모달 개선 / 드래그버튼 호버영역 확장

### DIFF
--- a/src/components/dashboard/modal/create-column-form.tsx
+++ b/src/components/dashboard/modal/create-column-form.tsx
@@ -20,7 +20,7 @@ export default function CreateColumnForm({
           htmlFor='new-column-name'
           className='mb-2 block text-lg leading-6 font-medium'
         >
-          대시보드 이름
+          컬럼 이름
           <span className='text-violet align-baseline text-lg'> *</span>
         </label>
         <input

--- a/src/components/dashboard/modal/manage-column-modal.tsx
+++ b/src/components/dashboard/modal/manage-column-modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import DeleteColumnModal from '@/components/dashboard/modal/delete-column-modal';
 import ManageColumnForm from '@/components/dashboard/modal/manage-column-form';
 import type {
@@ -62,7 +62,10 @@ export default function ManageColumnModal({
     .filter((colName) => colName !== column?.title)
     .some((colName) => colName.toLowerCase() === formData.name.toLowerCase());
 
-  const isUpdateDisabled = !formData.name.trim() || isDuplicate;
+  // 변경사항이 있는지 확인
+  const hasChanges = formData.name.trim() !== (column?.title || '');
+
+  const isUpdateDisabled = !formData.name.trim() || isDuplicate || !hasChanges;
 
   if (!column) {
     return null;
@@ -71,6 +74,7 @@ export default function ManageColumnModal({
   return (
     <>
       <ButtonModal
+        key={column.id}
         isOpen={isOpen}
         title='컬럼 관리'
         submitText='변경'

--- a/src/components/dashboard/sortable-task-card.tsx
+++ b/src/components/dashboard/sortable-task-card.tsx
@@ -36,14 +36,14 @@ export default function SortableTaskCard({
       ref={setNodeRef}
       style={style}
       {...attributes}
-      className='relative w-full'
+      className='group relative w-full'
     >
       <div className='w-full'>
         <ColumnTaskCard task={task} onEditTask={onEditTask} />
       </div>
       <div
         {...listeners}
-        className='absolute top-2 right-2 h-6 w-6 cursor-grab rounded bg-gray-200 opacity-0 transition-opacity hover:opacity-100 active:cursor-grabbing'
+        className='absolute top-2 right-2 h-6 w-6 cursor-grab rounded bg-gray-200 opacity-0 transition-opacity group-hover:opacity-100 active:cursor-grabbing'
       >
         <div className='flex h-full w-full items-center justify-center text-xs text-gray-500'>
           ↕


### PR DESCRIPTION
## 📝 Problem

> 해결하려는 문제가 무엇인가요?

<img width="611" height="440" alt="111111111111111111" src="https://github.com/user-attachments/assets/db8a8744-4b56-4b0b-ab40-3d0ab22e3dc6" />

1. 컬럼 추가 모달: 설명 문구가 '대시보드 이름 *'이라서 컬럼 모달과는 맞지 않음

<img width="673" height="474" alt="222222222" src="https://github.com/user-attachments/assets/bafb937b-4f1d-45a2-912d-b780111bfc9d" />

2. 컬럼 관리 모달: 모달을 열면 input요소가 기존 컬럼명이 기본값이 아닌 공백이 기본값
3. 할일카드 드래그버튼 호버 영역이 우측상단에 한정되어 있음

## ✅ Solving

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. 컬럼 추가 모달 문구 수정(대시보드 이름->컬럼 이름)

2. 컬럼 관리 모달에서 기존 컬럼명을 기본값으로 설정
  - useState의 초기값을 `column?.title || ''`로 설정
  - `key={column.id} prop`을 추가하여 컬럼이 변경될 때마다 컴포넌트가 리셋
3. 컬럼 관리 모달 변경사항 감지 로직 추가
  - hasChanges 변수를 추가하여 현재 입력값과 기존 컬럼명을 비교
  - isUpdateDisabled 로직에 !hasChanges 조건을 추가해서 실제로 변경사항이 있을 때만 변경 버튼이 활성화되도록
4. 할일카드 요소 전체에서 호버 시 드래그 버튼이 표시되도록 영역 확장
![녹화_2025_09_11_23_16_15_769](https://github.com/user-attachments/assets/982aa232-f60d-4774-8b05-b102a16f636c)
