### PR TITLE
fix: 컬럼 관리 및 댓글 모달 상태 초기화 개선

### DIFF
--- a/src/components/dashboard/modal/manage-column-modal.tsx
+++ b/src/components/dashboard/modal/manage-column-modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import DeleteColumnModal from '@/components/dashboard/modal/delete-column-modal';
 import ManageColumnForm from '@/components/dashboard/modal/manage-column-form';
 import type {
@@ -26,9 +26,18 @@ export default function ManageColumnModal({
   existingColumns = [],
 }: ManageColumnModalProps) {
   const [formData, setFormData] = useState<ManageColumnFormData>({
-    name: column?.title || '',
+    name: '',
   });
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const prevIsOpenRef = useRef(false);
+
+  // 모달이 열릴 때마다 formData 초기화
+  if (isOpen && !prevIsOpenRef.current && column) {
+    setFormData({
+      name: column.title || '',
+    });
+  }
+  prevIsOpenRef.current = isOpen;
 
   const handleClose = () => {
     onClose();

--- a/src/components/dashboard/modal/task-detail-modal.tsx
+++ b/src/components/dashboard/modal/task-detail-modal.tsx
@@ -44,6 +44,13 @@ export default function TaskDetailModal({
   const [newComment, setNewComment] = useState('');
   const commentRefreshRef = useRef<(() => void) | null>(null);
 
+  // 모달이 열리거나 task가 변경될 때마다 newComment 초기화
+  useEffect(() => {
+    if (isOpen) {
+      setNewComment('');
+    }
+  }, [isOpen, task?.id]);
+
   const handleClose = (): void => {
     setNewComment('');
     onClose();


### PR DESCRIPTION
## 📝 Problem

1. **컬럼 관리 모달**: 기존 컬럼명이 기본값으로 표시되지 않고, 변경사항이 없어도 변경 버튼이 활성화됨
2. **댓글 작성 모달**: A 할일카드에서 작성한 댓글이 B 할일카드에서도 그대로 표시됨
3. **모달 상태 초기화**: 수정 후 저장하지 않고 모달을 닫았다가 다시 열면 수정한 내용이 그대로 남아있음

## ✅ Solving

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

1. **컬럼 관리 모달 개선**:
   - 모달이 열릴 때 기존 컬럼명을 기본값으로 설정
   - 변경사항이 있을 때만 변경 버튼 활성화
   - 모달 열림 감지 로직으로 초기화

2. **댓글 작성 모달 개선**:
   - 다른 할일카드 열람 시 댓글 입력창 초기화
   - 모달이 열릴 때마다 댓글 입력창 초기화

3. **모달 상태 관리 최적화**:
   - `useRef`로 모달 열림 감지