### PR TITLE
fix: 할일카드 프로필 이미지 연동 / 달력 아이콘 이벤트 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,17 +80,34 @@ Taskify는 팀 협업을 위한 칸반 보드 기반 프로젝트/일정 관리 
 
 ## 🧱 기술 스택
 
-팀 규칙에 맞춘 실제 적용 스택
+### Tech Stack
+![Next JS](https://img.shields.io/badge/Next-black?style=for-the-badge&logo=next.js&logoColor=white)
+![TypeScript](https://img.shields.io/badge/typescript-%23007ACC.svg?style=for-the-badge&logo=typescript&logoColor=white)
+![TailwindCSS](https://img.shields.io/badge/tailwindcss-%2338B2AC.svg?style=for-the-badge&logo=tailwind-css&logoColor=white)
 
-- **Framework**: Next.js (Page Router)
-- **Language**: TypeScript
-- **Styling**: Tailwind CSS (디자인 토큰/유틸리티)
-- **State**: 로컬 state & URL 기반 (전역 상태 라이브러리 미사용, Context 지양)
-- **Data**: 공용 fetch 래퍼 사용 (credentials: 'include')
-- **Code Quality**: ESLint, Prettier
-- **Deploy**: Vercel
+### Development Environment
+![Visual Studio Code](https://img.shields.io/badge/Visual%20Studio%20Code-0078d7.svg?style=for-the-badge&logo=visual-studio-code&logoColor=white)
+![Git](https://img.shields.io/badge/git-%23F05033.svg?style=for-the-badge&logo=git&logoColor=white)
+![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)
+![ESLint](https://img.shields.io/badge/ESLint-4B3263?style=for-the-badge&logo=eslint&logoColor=white)
+![Prettier](https://img.shields.io/badge/prettier-%23F7B93E.svg?style=for-the-badge&logo=prettier&logoColor=black)
+![Vercel](https://img.shields.io/badge/vercel-%23000000.svg?style=for-the-badge&logo=vercel&logoColor=white)
+![Storybook](https://img.shields.io/badge/-Storybook-FF4785?style=for-the-badge&logo=storybook&logoColor=white)
+![Vitest](https://img.shields.io/badge/-Vitest-252529?style=for-the-badge&logo=vitest&logoColor=FCC72B)
 
-선택/확장 요소(옵션): Storybook(컴포넌트 문서화), Vitest(테스트) 
+### Architecture / State Management
+- Local state & URL 기반
+- Avoided global state libraries (Context API 지양)
+
+### Data Layer
+- Shared fetch wrapper
+- Configured with `credentials: 'include'`
+
+### Collaboration Tools
+![Discord](https://img.shields.io/badge/Discord-%235865F2.svg?style=for-the-badge&logo=discord&logoColor=white)
+![Notion](https://img.shields.io/badge/Notion-%23000000.svg?style=for-the-badge&logo=notion&logoColor=white)
+![Figma](https://img.shields.io/badge/figma-%23F24E1E.svg?style=for-the-badge&logo=figma&logoColor=white)
+
 
 ## 🔗 API & 인증
 

--- a/src/components/dashboard/column-task-card.tsx
+++ b/src/components/dashboard/column-task-card.tsx
@@ -109,6 +109,7 @@ export default function ColumnTaskCard({ task, onEditTask }: TaskCardProps) {
                 label={(task.manager.nickname || '').slice(0, 1)}
                 color={getProfileColorByIdHash(Number(task.manager.id))}
                 size='sm'
+                profileImageUrl={task.manager.profileImageUrl}
               />
             </div>
           </div>

--- a/src/components/dashboard/modal/create-task-form.tsx
+++ b/src/components/dashboard/modal/create-task-form.tsx
@@ -325,7 +325,8 @@ export default function CreateTaskForm({
           <button
             type='button'
             className='absolute inset-y-0 left-0 flex cursor-pointer items-center pl-4'
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
               const input = document.querySelector(
                 '#dueDate'
               ) as HTMLInputElement;

--- a/src/components/dashboard/modal/edit-task-form.tsx
+++ b/src/components/dashboard/modal/edit-task-form.tsx
@@ -386,8 +386,10 @@ export default function EditTaskForm({
             }}
           />
           <button
+            type='button'
             className='absolute inset-y-0 left-0 flex cursor-pointer items-center pl-4'
-            onClick={() => {
+            onClick={(e) => {
+              e.stopPropagation();
               const input = document.querySelector(
                 '#dueDate'
               ) as HTMLInputElement;

--- a/src/components/dashboard/modal/manage-column-form.tsx
+++ b/src/components/dashboard/modal/manage-column-form.tsx
@@ -14,16 +14,18 @@ export default function ManageColumnForm({
 }: ManageColumnFormProps) {
   const { theme } = useTheme();
 
-  let inputClass = '';
+  const getInputClass = () => {
+    if (hasError) {
+      return 'border-red-500 focus:border-red-500';
+    }
+    if (theme === 'dark') {
+      return 'border-[var(--auth-border)] bg-[var(--auth-input-bg)] text-white focus:border-green-500';
+    }
 
-  if (hasError) {
-    inputClass = 'border-red-500 focus:border-red-500';
-  } else if (theme === 'dark') {
-    inputClass =
-      'border-[var(--auth-border)] bg-[var(--auth-input-bg)] text-white focus:border-green-500';
-  } else {
-    inputClass = 'focus:border-violet border-gray-300 bg-white text-gray-900';
-  }
+    return 'focus:border-violet border-gray-300 bg-white text-gray-900';
+  };
+
+  const inputClass = getInputClass();
 
   return (
     <>


### PR DESCRIPTION
## 📝 Problem

> 해결하려는 문제가 무엇인가요?

- 할일카드 프로필 이미지 미표시: 담당자의 프로필 이미지가 할일카드에 제대로 연동되지 않음
- 달력 아이콘 클릭 시 모달이 닫히는 이슈

## ✅ Solving

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 프로필 이미지 표시 수정:
  - ChipProfile 컴포넌트에 profileImageUrl prop 추가
  - task.manager.profileImageUrl을 전달하여 실제 프로필 이미지 표시
- 달력 아이콘 이벤트 버블링 방지
  - create-task-form.tsx와 edit-task-form.tsx에서 달력 아이콘 버튼에 e.stopPropagation() 추가
  - type='button' 속성 추가로 폼 제출 방지